### PR TITLE
LuaRocks packaging added

### DIFF
--- a/luaxxhash-scm-1.rockspec
+++ b/luaxxhash-scm-1.rockspec
@@ -1,0 +1,20 @@
+package = "luaxxhash"
+version = "scm-1"
+source = {
+  url = "git://github.com/szensk/luaxxhash",
+}
+description = {
+  summary = "A LuaJIT implementation of xxhash",
+  detailed = [[
+   A LuaJIT implementation of xxhash.
+   Doesn't require bindings. Doesn't implement digest.
+  ]],
+  homepage = "https://github.com/szensk/luaxxhash",
+  license = "MIT"
+}
+build = {
+  type = "builtin",
+  modules = {
+    luaxxhash = "luaxxhash.lua"
+  }
+}

--- a/releases/luaxxhash-1.0.0-1.rockspec
+++ b/releases/luaxxhash-1.0.0-1.rockspec
@@ -1,0 +1,21 @@
+package = "luaxxhash"
+version = "1.0.0-1"
+source = {
+  url = "git://github.com/szensk/luaxxhash",
+  tag = "1.0.0",
+}
+description = {
+  summary = "A LuaJIT implementation of xxhash",
+  detailed = [[
+   A LuaJIT implementation of xxhash.
+   Doesn't require bindings. Doesn't implement digest.
+  ]],
+  homepage = "https://github.com/szensk/luaxxhash",
+  license = "MIT"
+}
+build = {
+  type = "builtin",
+  modules = {
+    luaxxhash = "luaxxhash.lua"
+  }
+}


### PR DESCRIPTION
Hi @szensk! 

This PR adds the rockspecs for dev and stable releases, so luaxxhash can be released using LuaRocks.

We want to use luaxxhash as a dependency for other projects, that's why it is interesting to have it released in LuaRocks.

I don't know if this project is still maintained, if it's not, we can release it under our org name. If it is still maintained but you don't want to take care of this, we can do it as well. If later you change your mind, we can transfer the project ownership in LuaRocks. Please let me know what works better for you.

Thanks!